### PR TITLE
feat: hard quantize edge cases (nans, constants)

### DIFF
--- a/fengi/utils_feat/quantization.py
+++ b/fengi/utils_feat/quantization.py
@@ -211,7 +211,18 @@ def hard_quantize(x, bins):
     Returns:
         The quantized signal where each value is rounded to the nearest quantization level.
     """
-    quantiles = np.quantile(x, bins)
+
+    if x.nunique() == 1 or x.isna().all():
+        # The series x is not quantizable in a meaningful way, returning a series of NaNs.
+        x = np.full(len(x), np.nan)
+        return x
+
+    quantiles = np.quantile(x.dropna(), bins)  # Exclude NaN values for computing quantiles
     quant_index = np.digitize(x, quantiles, right=True)
-    x = np.round((quant_index) / (len(bins) - 1), 2)
-    return x
+
+    x_quantized = np.round((quant_index) / (len(bins) - 1), 2)
+
+    # Preserve NaN values in the output
+    x_quantized[x.isna()] = np.nan
+
+    return x_quantized

--- a/fengi/utils_feat/quantization.py
+++ b/fengi/utils_feat/quantization.py
@@ -6,8 +6,8 @@ Resources: https://github.com/ninfueng/lloyd-max-quantizer
 
 Original Author: Ninnart Fuengfusin
 """
-import pandas as pd
 import numpy as np
+import pandas as pd
 import scipy.integrate as integrate
 
 

--- a/fengi/utils_feat/quantization.py
+++ b/fengi/utils_feat/quantization.py
@@ -6,6 +6,7 @@ Resources: https://github.com/ninfueng/lloyd-max-quantizer
 
 Original Author: Ninnart Fuengfusin
 """
+import pandas as pd
 import numpy as np
 import scipy.integrate as integrate
 
@@ -201,7 +202,7 @@ def quantize(x, bits=7, iterations=10):
     return best_x_hat_q
 
 
-def hard_quantize(x, bins):
+def hard_quantize(x: pd.Series, bins: list) -> pd.Series:
     """Perform hard quantization on an input signal.
 
     Args:


### PR DESCRIPTION
## Description

The function was raising an error in the case of a Series full of nans.
It was not handling the case in which there were nans in the Series.

Default behaviour is to return a Series filled with nans if we have in input a series with full of nans or a constant. If there are a few nans, they are dropped from the quantization process and added afterward.