### PR TITLE
feat(utils_feat/quantization): manage nans and constant edge cases

### DIFF
--- a/fengi/utils_feat/quantization.py
+++ b/fengi/utils_feat/quantization.py
@@ -7,6 +7,7 @@ Resources: https://github.com/ninfueng/lloyd-max-quantizer
 Original Author: Ninnart Fuengfusin
 """
 import numpy as np
+import pandas as pd
 import scipy.integrate as integrate
 
 
@@ -205,7 +206,7 @@ def quantize(x, bits=7, iterations=10):
     return best_x_hat_q
 
 
-def hard_quantize(x, bins):
+def hard_quantize(x: pd.Series, bins: list) -> pd.Series:
     """Perform hard quantization on an input signal.
 
     Args:
@@ -215,7 +216,18 @@ def hard_quantize(x, bins):
     Returns:
         The quantized signal where each value is rounded to the nearest quantization level.
     """
-    quantiles = np.quantile(x, bins)
+
+    if x.nunique() == 1 or x.isna().all():
+        # The series x is not quantizable in a meaningful way, returning a series of NaNs.
+        x = np.full(len(x), np.nan)
+        return x
+
+    quantiles = np.quantile(x.dropna(), bins)
     quant_index = np.digitize(x, quantiles, right=True)
-    x = np.round((quant_index) / (len(bins) - 1), 2)
-    return x
+
+    x_quantized = np.round((quant_index) / (len(bins) - 1), 2)
+
+    # Preserve NaN values in the output
+    x_quantized[x.isna()] = np.nan
+
+    return x_quantized

--- a/fengi/utils_feat/quantization.py
+++ b/fengi/utils_feat/quantization.py
@@ -206,7 +206,7 @@ def quantize(x, bits=7, iterations=10):
     return best_x_hat_q
 
 
-def hard_quantize(x: pd.Series, bins: list) -> pd.Series:
+def hard_quantize(x: pd.Series, bins: list) -> np.array:
     """Perform hard quantization on an input signal.
 
     Args:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "feature-engineering"
-version = "0.2.0"
+version = "0.3.0"
 description = "Feature Engineering for Financial Machine Learning."
 readme = "README.md"
 authors = ["CrunchDAO"]

--- a/tests/test_hard_quantize.py
+++ b/tests/test_hard_quantize.py
@@ -1,0 +1,39 @@
+import unittest
+
+import numpy as np
+import pandas as pd
+
+from fengi.utils_feat.quantization import hard_quantize
+
+
+class TestHardQuantize(unittest.TestCase):
+    def setUp(self):
+        self.bins = [0, 0.5, 1]
+
+    def normal_test(self):
+        x = pd.Series(np.linspace(0, 5, 100)).rank(pct=True, method="first")
+        expected = np.where(x < 0.5, 0, np.where(x < 1, 0.5, 1))
+        result = hard_quantize(x, self.bins)
+        np.testing.assert_array_almost_equal(result, expected)
+
+    def test_single_value(self):
+        x = pd.Series([1, 1, 1]).rank(pct=True, method="first")
+        expected = np.array([0.0, 0.5, 1.0])
+        result = hard_quantize(x, self.bins)
+        np.testing.assert_array_equal(result, expected)
+
+    def test_nan_values(self):
+        x = pd.Series([np.nan, np.nan, np.nan]).rank(pct=True, method="first")
+        expected = np.array([np.nan, np.nan, np.nan])
+        result = hard_quantize(x, self.bins)
+        np.testing.assert_array_equal(result, expected)
+
+    def test_hard_quantize_partial_nan_series(self):
+        partial_nan_series = pd.Series([1.0, 2.0, np.nan, 4.0, 5.0])
+        result = hard_quantize(partial_nan_series, self.bins)
+        expected = np.array([0.0, 0.5, np.nan, 1.0, 1.0])
+        np.testing.assert_array_equal(result, expected)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Description

The function was raising an error in the case of a Series full of nans.
It was not handling the case in which there were nans in the Series.

Default behaviour is to return a Series filled with nans if we have in input a series with full of nans or a constant. If there are a few nans, they are dropped from the quantization process and added afterward.
